### PR TITLE
Added address pattern filter for invoking osc methods

### DIFF
--- a/Osc/OscServer.cs
+++ b/Osc/OscServer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 
@@ -71,7 +72,8 @@ namespace Osc
 
                 lock (methodsLock)
                 {
-                    foreach (var method in methodSet)
+                    // Invoke each method that has the same OSC Address pattern
+                    foreach (var method in methodSet.Where(method => method.OscAddress.Segments.SequenceEqual(message.AddressPattern.Segments)))
                     {
                         method.Dispatch(message);
                     }


### PR DESCRIPTION
I was having a problem where every method was being called no matter what OSC message was received. I added this filter because I assumed that was the indented behaviour.